### PR TITLE
Use darwin_x86_64 as our MacOS CPU type

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,7 +18,7 @@ config_setting(
 
 config_setting(
     name = "macos_x86_64",
-    values = {"cpu": "darwin"},
+    values = {"cpu": "darwin_x86_64"},
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This requires that the XCode app be installed, but it enables the use of Bazel's MacOS-specific rules.